### PR TITLE
Deploy the playground to GH pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: deploy
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Build site
+        run: deno task build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: "dist"
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .vite/
+dist/

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
-    "dev": "deno run -A npm:vite"
+    "dev": "deno run -A npm:vite",
+    "build": "deno run -A npm:vite build"
   },
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "dom.asynciterable", "deno.ns"],


### PR DESCRIPTION
After some thought, I decided that setting up tools.isentropic.dev or even putting a /tools path on isentropic.dev wasn't worth it. It's much simpler (and more customary) to just deploy this to GH pages. 

I'm probably gonna immediately merge this so I can verify that it works. There's nothing terribly special here. Just adds the standard workflow to deploy to GH pages.
